### PR TITLE
A benchmark to check for high-frequency alloc

### DIFF
--- a/firmware_test.go
+++ b/firmware_test.go
@@ -1,0 +1,27 @@
+package godrone
+
+import "testing"
+
+func BenchmarkControlLoop(b *testing.B) {
+	b.ReportAllocs()
+	mb, err := OpenMotorboard("/dev/null")
+	if err != nil {
+		b.Fatal(err)
+	}
+	f, _ := NewCustomFirmware(&mockNavboard{}, mb)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.Control()
+	}
+}
+
+type mockNavboard struct{}
+
+func (b *mockNavboard) Read() (data Navdata, err error) {
+	return Navdata{
+		Seq:      1,
+		AccRoll:  2000,
+		AccPitch: 2000,
+		AccYaw:   8000,
+	}, nil
+}

--- a/motorboard.go
+++ b/motorboard.go
@@ -11,7 +11,8 @@ const (
 	setLeds   = 0x60
 )
 
-// A MotorLedWriter is an interface that allows us to make a MockMotorboard.
+// A MotorLedWriter is an interface that allows you to substitute a mock
+// motor board for a real one for testing.
 type MotorLedWriter interface {
 	WriteSpeeds(speeds [4]float64) error
 	WriteLeds(leds [4]LedColor) error
@@ -56,8 +57,7 @@ func (m *Motorboard) WriteSpeeds(speeds [4]float64) error {
 // cmd = 011rrrrx xxxggggx (used to be 011grgrg rgrxxxxx in AR Drone 1.0)
 // see: https://github.com/ardrone/ardrone/blob/master/ardrone/motorboard/motorboard.c#L243
 func (m *Motorboard) WriteLeds(leds [4]LedColor) error {
-	cmd := make([]byte, 2)
-	cmd[0] = setLeds
+	cmd := []byte{setLeds, 0}
 
 	for i, color := range leds {
 		if color == LedRed || color == LedOrange {

--- a/navboard.go
+++ b/navboard.go
@@ -16,7 +16,8 @@ const (
 
 var packetHeader = []byte{packetSize, 0x00}
 
-// A NavdataReader is an interface that allows is to make a MockNavboard.
+// A NavdataReader is an interface that allows you to make a mock
+// navboard for testing.
 type NavdataReader interface {
 	Read() (data Navdata, err error)
 }


### PR DESCRIPTION
To see how many allocations happen per pass through
the control loop: go test -bench=.

We expect that zero allocations happen in the control loop,
but in fact 2 happen due to runtime.convertT2I in os.(*File).Write.
Discussing with Go maintainers how to fix this.

We still need a mock navboard that actually calls os.(*File).Read
to check for the same kind of problem there, but a quick read
of os/file.go and os/file_unix.go now that I understand the problem
makes me think it won't happen on the Read side.

Another critical source of garbage to minimize is from the
websocket, but that's work for another day.
